### PR TITLE
fix: Unencode encoded unicode text

### DIFF
--- a/src/annotation.ts
+++ b/src/annotation.ts
@@ -214,7 +214,7 @@ export class LineAnnotation implements Disposable {
 		}
 		else {
 			if (value.text) {
-				return value.text + this.buildMessage(value.extras || []);
+				return this.unescapeUnicode(value.text) + this.buildMessage(value.extras || []);
 			}
 			else if (value.translate) {
 				return value.translate + this.buildMessage(value.extras || []);
@@ -250,5 +250,12 @@ export class LineAnnotation implements Disposable {
 			.replace(/</g, '\\<')
 			.replace(/>/g, '\\>')
 			.replace(/\*/g, '\\*');
+	}
+
+	// Unescape escape Unicode characters
+	unescapeUnicode(s: string): string {
+		return s.replace(/\\u([a-fA-F0-9]{4})/g, function (_, group) {
+			return String.fromCharCode(parseInt(group, 16));
+		});
 	}
 }


### PR DESCRIPTION
Thank you for creating a great extension.

Fixed the problem where Unicode encoded text would be displayed as encoded.

![image](https://user-images.githubusercontent.com/8929706/132948987-25db756c-60f6-46bd-a9e1-c47aeb10c27d.png)
![image](https://user-images.githubusercontent.com/8929706/132948990-21d43170-5753-4fdc-b158-6082484ebc1d.png)

package: [tellraw-preview.zip](https://github.com/oOBoomberOo/tellraw-preview/files/7147927/tellraw-preview.zip)
